### PR TITLE
Patch "Cannot read property 'optionsContainer' of undefined" error

### DIFF
--- a/build/rnpm.js
+++ b/build/rnpm.js
@@ -1862,7 +1862,7 @@
           return _this6._onOptionsLayout(e, instance.getName(), isOutside);
         };
 
-        var style = [optionsContainerStyle, customStyles.optionsContainer];
+        var style = [optionsContainerStyle, customStyles ? customStyles.optionsContainer : {}];
         var layouts = {
           windowLayout: windowLayout,
           triggerLayout: triggerLayout,


### PR DESCRIPTION
This is for the error outlined here: https://github.com/instea/react-native-popup-menu/issues/292.